### PR TITLE
added .cache/clangd to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,5 @@
 .idea
 cmake-build-*
 xbuild
+.cache/clangd
 


### PR DESCRIPTION
Clangd is a popular LSP server for c/c++. Sadly it creates a lot of cache files under .cache/clangd. Let's git ignore them.